### PR TITLE
issues/23: render unformatted //test comment correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Most recent version is listed first.
   work/analyze the module that is passed in as an argument to `ote`
 - Have all static analysis passes succeed: https://github.com/komuw/ote/pull/20
 - dont analyze Go files inside vendor/ directory: https://github.com/komuw/ote/pull/21
+- render unformatted `//test` comment correctly: https://github.com/komuw/ote/pull/24
 
 
 ## v0.0.3

--- a/comment.go
+++ b/comment.go
@@ -88,8 +88,8 @@ func setTest(line *modfile.Line, add bool) {
 		com.Token = "// test; " + text
 	} else {
 		// Removing comment.
-		f := strings.Fields(line.Suffix[0].Token)
-		if len(f) == 2 {
+		f := strings.TrimSpace(strings.ReplaceAll(line.Suffix[0].Token, " ", ""))
+		if f == "//test" {
 			// Remove whole comment.
 			line.Suffix = nil
 			return

--- a/comment_test.go
+++ b/comment_test.go
@@ -141,6 +141,39 @@ func TestSetTest(t *testing.T) {
 			expected: "",
 			add:      false,
 		},
+
+		{
+			line: &modfile.Line{
+				Comments: modfile.Comments{
+					Suffix: []modfile.Comment{
+						{
+							// existing `test` comment that has no spacing with the slashes is removed
+							Token:  "//test\n",
+							Suffix: true,
+						},
+					},
+				},
+			},
+			expected: "",
+			add:      false,
+		},
+
+		{
+			line: &modfile.Line{
+				Comments: modfile.Comments{
+					Suffix: []modfile.Comment{
+						{
+							// existing `test` comment that has no spacing with the slashes
+							// and has no newline is removed
+							Token:  "//test",
+							Suffix: true,
+						},
+					},
+				},
+			},
+			expected: "",
+			add:      false,
+		},
 	}
 
 	for _, v := range tt {


### PR DESCRIPTION
## What(What have you changed/added/removed?)
- render unformatted //test comment correctly
- Previously if you had a `go.mod` file like
```
module someModule
require (
    golang.org/someNonTestModule v0.4.2 //test
)
```
  When you run `ote` on it, it would render as;
```
module someModule
require (
    golang.org/someNonTestModule v0.4.2 //st
)
```
  `ote` would be unable to remove the `//test` comment completely because there was no space between the `//` and `test`
- This is a bug inherited from the `golang.org/x/mod` code[2]

## Why(Why did you change/add/remove it?)
1. Fixes: https://github.com/komuw/ote/issues/23
2. https://github.com/komuw/ote/blob/ae34c4ef8690fb90ddf0aaf55b8e7402639695da/comment.go#L13-L16
