### PR TITLE
issues/36: create separate require block for test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Most recent version is listed first.  
 
 
+## v0.0.7
+- List test-only dependencies in their own require block: https://github.com/komuw/ote/pull/37
+
+
 ## v0.0.6
 - Remove unnecessary loop, so as to improve perfomance: https://github.com/komuw/ote/pull/33
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ module github.com/pkg/myPkg
 require (
 	github.com/Shopify/sarama v1.26.4
 	github.com/golang/protobuf v1.4.2 // indirect
-	github.com/google/go-cmp v0.5.0 // test
 	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
 	github.com/nats-io/nats.go v1.10.0
-	github.com/stretchr/testify v1.6.1 // test; priorComment
 	golang.org/x/mod v0.3.0
+)
+
+require (
+	github.com/google/go-cmp v0.5.0 // test
+	github.com/stretchr/testify v1.6.1 // test; priorComment
 )
 ```
 ie; assuming that `github.com/google/go-cmp` and `github.com/stretchr/testify` are test-only dependencies in your application.

--- a/README.md
+++ b/README.md
@@ -44,26 +44,36 @@ If your application has a `go.mod` file like the following;
 ```bash
 module github.com/pkg/myPkg
 
+go 1.17
+
 require (
 	github.com/Shopify/sarama v1.26.4
-	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.0
-	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
 	github.com/nats-io/nats.go v1.10.0
 	github.com/stretchr/testify v1.6.1 // priorComment
 	golang.org/x/mod v0.3.0
+)
+
+require (
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
 )
 ```
 running `ote` will update the `go.mod` to the following;
 ```bash
 module github.com/pkg/myPkg
 
+go 1.17
+
 require (
 	github.com/Shopify/sarama v1.26.4
-	github.com/golang/protobuf v1.4.2 // indirect
-	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
 	github.com/nats-io/nats.go v1.10.0
 	golang.org/x/mod v0.3.0
+)
+
+require (
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/komuw/ote
 go 1.16
 
 require (
-	github.com/frankban/quicktest v1.12.1 // test
 	golang.org/x/mod v0.4.2
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
 	golang.org/x/tools v0.1.0
 )
+
+require github.com/frankban/quicktest v1.12.1 // test

--- a/import.go
+++ b/import.go
@@ -112,7 +112,7 @@ func fetchModule(root, importPath string) (string, error) {
 	if len(pkgs) > 1 {
 		return "", fmt.Errorf("import %s produced greater than 1 packages", importPath)
 	}
-	if len(pkgs) < 0 {
+	if len(pkgs) <= 0 {
 		return "", fmt.Errorf("import %s does not belong to any package", importPath)
 	}
 

--- a/modfile.go
+++ b/modfile.go
@@ -79,13 +79,13 @@ func addTestRequireBlock(f *modfile.File, testLines []*modfile.Line) {
 	}
 
 	type aha struct {
-		name    string
-		ver     string
-		comment string
+		name string
+		ver  string
+		com  string
 	}
 	yes := []aha{}
 	for _, t := range testLines {
-		yes = append(yes, aha{name: t.Token[0], ver: t.Token[1], comment: "// test"})
+		yes = append(yes, aha{name: t.Token[0], ver: t.Token[1], com: testComment})
 	}
 
 	for _, y := range yes {
@@ -97,7 +97,7 @@ func addTestRequireBlock(f *modfile.File, testLines []*modfile.Line) {
 	xx := []*modfile.Line{}
 	for _, y := range yes {
 		xx = append(xx,
-			&modfile.Line{Token: []string{y.name, y.ver, y.comment}},
+			&modfile.Line{Token: []string{y.name, y.ver, y.com}},
 		)
 	}
 

--- a/modfile.go
+++ b/modfile.go
@@ -30,7 +30,7 @@ func getModFile(gomodFile string) (*modfile.File, error) {
 
 // updateMod updates the in-memory modfile
 func updateMod(trueTestModules []string, f *modfile.File) error {
-	if len(trueTestModules) < 0 {
+	if len(trueTestModules) <= 0 {
 		// if there are no test dependencies, we need to go through all the deps and
 		// remove any test comments that there may be there.
 		for _, fr := range f.Require {

--- a/modfile.go
+++ b/modfile.go
@@ -76,7 +76,6 @@ func addTestRequireBlock(f *modfile.File, lineMods []lineMod) {
 		require (
 				github.com/fatih/color v1.12.0 // test
 				github.com/frankban/quicktest v1.12.1 // test
-				github.com/go-xorm/builder v0.3.4 // test
 			)
 	*/
 

--- a/modfile.go
+++ b/modfile.go
@@ -58,8 +58,35 @@ func updateMod(trueTestModules []string, f *modfile.File) error {
 	return nil
 }
 
+func addTestRequirements(f *modfile.File) {
+	// Add a new require block after the last "require".
+	// This new block will house test-only requirements
+	// eg.
+	/*
+		require (
+				github.com/fatih/color v1.12.0 // test
+				github.com/frankban/quicktest v1.12.1 // test
+				github.com/go-xorm/builder v0.3.4 // test
+			)
+	*/
+
+	newTestBlock := &modfile.LineBlock{
+		Token: []string{"require"},
+		Line: []*modfile.Line{
+			&modfile.Line{Token: []string{"github.com/fatih/color", "v1.12.0", "// test"}},
+			&modfile.Line{Token: []string{"github.com/go-xorm/builder", "v0.3.4", "// test"}},
+			&modfile.Line{Token: []string{"github.com/frankban/quicktest", "v1.12.1", "// test"}},
+		},
+	}
+
+	f.Syntax.Stmt = append(f.Syntax.Stmt, newTestBlock)
+	f.Syntax.Cleanup()
+}
+
 // writeMod updates the on-disk modfile
 func writeMod(f *modfile.File, gomodFile string, w io.Writer, readonly bool) error {
+	addTestRequirements(f)
+
 	f.SortBlocks()
 	f.Cleanup()
 

--- a/modfile.go
+++ b/modfile.go
@@ -12,7 +12,7 @@ import (
 type lineMod struct {
 	name string
 	ver  string
-	com  string
+	coms modfile.Comments
 }
 
 func getModFile(gomodFile string) (*modfile.File, error) {
@@ -47,7 +47,7 @@ func updateMod(trueTestModules []string, f *modfile.File) error {
 				// add test comment
 				line := fr.Syntax
 				setTest(line, true)
-				lineMods = append(lineMods, lineMod{name: line.Token[0], ver: line.Token[1], com: testComment})
+				lineMods = append(lineMods, lineMod{name: line.Token[0], ver: line.Token[1], coms: line.Comments})
 			}
 		}
 	}
@@ -90,7 +90,10 @@ func addTestRequireBlock(f *modfile.File, lineMods []lineMod) {
 
 	testLines := []*modfile.Line{}
 	for _, y := range lineMods {
-		testLines = append(testLines, &modfile.Line{Token: []string{y.name, y.ver, y.com}})
+		testLines = append(testLines, &modfile.Line{
+			Token:    []string{y.name, y.ver},
+			Comments: y.coms,
+		})
 	}
 	newTestBlock := &modfile.LineBlock{
 		Token: []string{"require"},

--- a/modfile.go
+++ b/modfile.go
@@ -78,21 +78,38 @@ func addTestRequireBlock(f *modfile.File, testLines []*modfile.Line) {
 		return
 	}
 
+	type aha struct {
+		name    string
+		ver     string
+		comment string
+	}
+	yes := []aha{}
+	for _, t := range testLines {
+		yes = append(yes, aha{name: t.Token[0], ver: t.Token[1], comment: "// test"})
+	}
+
+	for _, y := range yes {
+		// since test-only deps are in their own require blocks,
+		// drop them from the main one.
+		f.DropRequire(y.name)
+	}
+
+	xx := []*modfile.Line{}
+	for _, y := range yes {
+		xx = append(xx,
+			&modfile.Line{Token: []string{y.name, y.ver, y.comment}},
+		)
+	}
+
 	newTestBlock := &modfile.LineBlock{
 		Token: []string{"require"},
-		Line:  testLines,
+		Line:  xx,
 		// Line: []*modfile.Line{
 		// 	&modfile.Line{Token: []string{"github.com/fatih/color", "v1.12.0", "// test"}},
 		// 	&modfile.Line{Token: []string{"github.com/go-xorm/builder", "v0.3.4", "// test"}},
 		// 	&modfile.Line{Token: []string{"github.com/frankban/quicktest", "v1.12.1", "// test"}},
 		// },
 	}
-
-	// for _, t := range tst {
-	// 	// since test-only deps are in their own require blocks,
-	// 	// drop them from the main one.
-	// 	f.DropRequire(t)
-	// }
 
 	f.Syntax.Stmt = append(f.Syntax.Stmt, newTestBlock)
 	f.Syntax.Cleanup()

--- a/modfile.go
+++ b/modfile.go
@@ -78,14 +78,14 @@ func addTestRequireBlock(f *modfile.File, testLines []*modfile.Line) {
 		return
 	}
 
-	type aha struct {
+	type lineMod struct {
 		name string
 		ver  string
 		com  string
 	}
-	yes := []aha{}
+	yes := []lineMod{}
 	for _, t := range testLines {
-		yes = append(yes, aha{name: t.Token[0], ver: t.Token[1], com: testComment})
+		yes = append(yes, lineMod{name: t.Token[0], ver: t.Token[1], com: testComment})
 	}
 
 	for _, y := range yes {

--- a/modfile.go
+++ b/modfile.go
@@ -85,7 +85,7 @@ func addTestRequireBlock(f *modfile.File, lineMods []lineMod) {
 	for _, y := range lineMods {
 		// since test-only deps are in their own require blocks,
 		// drop them from the main one.
-		f.DropRequire(y.name)
+		_ = f.DropRequire(y.name)
 	}
 
 	testLines := []*modfile.Line{}

--- a/ote_test.go
+++ b/ote_test.go
@@ -41,6 +41,13 @@ require (
 	rsc.io/quote v1.5.2
 )
 
+exclude golang.org/x/net v1.2.3
+
+retract (
+	v1.0.1 // Contains retractions only.
+	v1.0.0 // Published accidentally.
+)
+
 require (
 	github.com/frankban/quicktest v1.12.1 // test
 	github.com/shirou/gopsutil v2.20.9+incompatible // test; PriorComment

--- a/ote_test.go
+++ b/ote_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -32,15 +33,18 @@ replace github.com/shirou/gopsutil => github.com/hashicorp/gopsutil v2.18.13-0.2
 require (
 	github.com/LK4D4/joincontext v0.0.0-20171026170139-1724345da6d5
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
-	github.com/frankban/quicktest v1.12.1 // test
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/hashicorp/nomad v1.0.4 // The test comment should be removed by ote
 	github.com/pkg/errors v0.9.1
-	github.com/shirou/gopsutil v2.20.9+incompatible // test; PriorComment
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210501142056-aec3718b3fa0 // indirect
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	rsc.io/quote v1.5.2
+)
+
+require (
+	github.com/frankban/quicktest v1.12.1 // test
+	github.com/shirou/gopsutil v2.20.9+incompatible // test; PriorComment
 )
 
 `,
@@ -162,6 +166,13 @@ require (
 			}
 
 			got := w.String()
+
+			fmt.Println()
+			fmt.Println()
+			t.Log(got)
+			fmt.Println()
+			fmt.Println()
+
 			c.Assert(got, qt.Equals, tt.want)
 		})
 	}

--- a/ote_test.go
+++ b/ote_test.go
@@ -119,7 +119,6 @@ go 1.16
 require (
 	github.com/alexedwards/scs/v2 v2.4.0
 	github.com/aws/aws-sdk-go v1.38.31
-	github.com/benweissmann/memongo v0.1.1 // test
 	github.com/go-kit/kit v0.10.0
 	github.com/ishidawataru/sctp v0.0.0-20210226210310-f2269e66cdee
 	github.com/ory/herodot v0.9.5
@@ -128,6 +127,8 @@ require (
 	github.com/zeebo/errs/v2 v2.0.3
 	go.uber.org/zap v1.13.0
 )
+
+require github.com/benweissmann/memongo v0.1.1 // test
 
 `,
 		},

--- a/ote_test.go
+++ b/ote_test.go
@@ -100,8 +100,9 @@ go 1.16
 require (
 	github.com/ethereum/go-ethereum v1.10.2
 	github.com/kingzbauer/africastalking-go v0.0.2-alpha.1
-	go.uber.org/goleak v1.1.10 // test
 )
+
+require go.uber.org/goleak v1.1.10 // test
 
 `,
 		},

--- a/ote_test.go
+++ b/ote_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -171,13 +170,6 @@ require github.com/benweissmann/memongo v0.1.1 // test
 			}
 
 			got := w.String()
-
-			fmt.Println()
-			fmt.Println()
-			t.Log(got)
-			fmt.Println()
-			fmt.Println()
-
 			c.Assert(got, qt.Equals, tt.want)
 		})
 	}

--- a/ote_test.go
+++ b/ote_test.go
@@ -71,15 +71,18 @@ require (
 	github.com/hashicorp/vault/api v1.1.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/shirou/gopsutil v3.21.4+incompatible // test
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20210415154028-4f45737414dc // indirect
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // test
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+)
+
+require (
+	github.com/shirou/gopsutil v3.21.4+incompatible // test
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // test
 )
 
 `,

--- a/testdata/mod1/go.mod
+++ b/testdata/mod1/go.mod
@@ -17,3 +17,10 @@ require (
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	rsc.io/quote v1.5.2
 )
+
+exclude golang.org/x/net v1.2.3
+
+retract (
+	v1.0.1 // Contains retractions only.
+	v1.0.0 // Published accidentally.
+)


### PR DESCRIPTION
## What(What have you changed/added/removed?)
- List test-only dependencies in their own require block

## Why(Why did you change/add/remove it?)
- Fixes: https://github.com/komuw/ote/issues/36
- Go as of version 1.17 will be listing indirect dependencies in their own require block.    
   see: https://go-review.googlesource.com/c/go/+/325922/    
   It thus makes sense to do the same for test-only dependencies.
